### PR TITLE
Luminance calculation optimisation

### DIFF
--- a/autocrop.go
+++ b/autocrop.go
@@ -53,13 +53,15 @@ func BoundsForThreshold(img *image.NRGBA, energyThreshold float32) image.Rectang
 // Energies returns the total row and column energies for the specified region
 // of an image.
 func Energies(img *image.NRGBA, r image.Rectangle) (cols, rows []float32) {
+	width, luminances, alphas := luminancesAndAlphas(img, r)
+
 	cols = make([]float32, r.Dx(), r.Dx())
 	rows = make([]float32, r.Dy(), r.Dy())
 
 	// Calculate total column and row energies
 	for i, row := r.Min.Y, 0; i < r.Max.Y; i, row = i+1, row+1 {
 		for j, col := r.Min.X, 0; j < r.Max.X; j, col = j+1, col+1 {
-			e := energy(img, j, i)
+			e := energy(width, luminances, alphas, j, i)
 			cols[col] += e
 			rows[row] += e
 		}
@@ -85,22 +87,16 @@ func colourAt(img *image.NRGBA, x, y int) (col srgb.Color, alpha float32) {
 	return srgb.ColorFromNRGBA(img.NRGBAAt(x, y))
 }
 
-func energy(img *image.NRGBA, x, y int) float32 {
-	neighbours := [8]float32{
-		luminance(colourAt(img, x-1, y-1)),
-		luminance(colourAt(img, x, y-1)),
-		luminance(colourAt(img, x+1, y-1)),
-		luminance(colourAt(img, x-1, y)),
-		luminance(colourAt(img, x+1, y)),
-		luminance(colourAt(img, x-1, y+1)),
-		luminance(colourAt(img, x, y+1)),
-		luminance(colourAt(img, x+1, y+1)),
-	}
+func energy(width int, luminances, alphas []float32, x, y int) float32 {
+	center := y*width + x
 
-	eX := neighbours[0] + neighbours[3] + neighbours[5] - neighbours[2] - neighbours[4] - neighbours[7]
-	eY := neighbours[0] + neighbours[1] + neighbours[2] - neighbours[5] - neighbours[6] - neighbours[7]
+	// North west + west + south west - north east - east - south east
+	eX := luminances[center-width-1] + luminances[center-1] + luminances[center+width-1] - luminances[center-width+1] - luminances[center+1] - luminances[center+width+1]
 
-	return float32((math.Abs(float64(eX)) + math.Abs(float64(eY))) * (float64(img.NRGBAAt(x, y).A) / 255))
+	// North west + north + north east - south west - south - south east
+	eY := luminances[center-width-1] + luminances[center-width] + luminances[center-width+1] - luminances[center+width-1] - luminances[center+width] - luminances[center+width+1]
+
+	return float32((math.Abs(float64(eX)) + math.Abs(float64(eY))) * float64(alphas[center]))
 }
 
 func findFirstEnergyBound(energies []float32, maxEnergy, threshold float32) (bound int) {
@@ -146,4 +142,28 @@ func findMaxEnergy(energies []float32) float32 {
 
 func luminance(c srgb.Color, alpha float32) float32 {
 	return c.Luminance() + alpha
+}
+
+func luminancesAndAlphas(img *image.NRGBA, r image.Rectangle) (width int, luminances, alphas []float32) {
+
+	// Need a 1 pixel border of luminances around the region specified by r
+	rWidth := r.Dx() + 2
+	rHeight := r.Dy() + 2
+
+	luminances = make([]float32, rWidth*rHeight, rWidth*rHeight)
+	alphas = make([]float32, rWidth*rHeight, rWidth*rHeight)
+
+	offset := 0
+
+	// Get the luminances and alphas for all pixels
+	for i, row := r.Min.Y-1, 0; i <= r.Max.Y; i, row = i+1, row+1 {
+		for j, col := r.Min.X-1, 0; j <= r.Max.X; j, col = j+1, col+1 {
+			c, a := colourAt(img, col, row)
+			luminances[offset] = luminance(c, a)
+			alphas[offset] = a
+			offset++
+		}
+	}
+
+	return rWidth, luminances, alphas
 }


### PR DESCRIPTION
This changes the luminance calculation to be done once up front rather than repeatedly during the energy calculation pass. This improves running time at the cost of more memory usage.

Before:

```
> go test -run=XXX -bench=EnergySummation -count=8
BenchmarkEnergySummation-56    	      60	  19912731 ns/op
BenchmarkEnergySummation-56    	      58	  19881756 ns/op
BenchmarkEnergySummation-56    	      60	  20051701 ns/op
BenchmarkEnergySummation-56    	      57	  19925334 ns/op
BenchmarkEnergySummation-56    	      60	  19934364 ns/op
BenchmarkEnergySummation-56    	      60	  19991013 ns/op
BenchmarkEnergySummation-56    	      58	  20027357 ns/op
BenchmarkEnergySummation-56    	      58	  19939651 ns/op
```

After:

```
> go test -run=XXX -bench=EnergySummation -count=8
BenchmarkEnergySummation-56    	     216	   5549046 ns/op
BenchmarkEnergySummation-56    	     218	   5518821 ns/op
BenchmarkEnergySummation-56    	     219	   5481677 ns/op
BenchmarkEnergySummation-56    	     218	   5501465 ns/op
BenchmarkEnergySummation-56    	     217	   5504081 ns/op
BenchmarkEnergySummation-56    	     217	   5480322 ns/op
BenchmarkEnergySummation-56    	     219	   5470919 ns/op
BenchmarkEnergySummation-56    	     218	   5492120 ns/op
```